### PR TITLE
fix the wrong process_time issue

### DIFF
--- a/coding/validator/forward.py
+++ b/coding/validator/forward.py
@@ -64,9 +64,14 @@ async def process_response(uid: int, async_generator: Awaitable):
         if chunk is not None:
             synapse = chunk  # last object yielded is the synapse itself with completion filled
 
+            # bt.logging.debug(f"process_time: synapse.dendrite.process_time}")
             # Assuming chunk holds the last value yielded which should be a synapse
             if isinstance(synapse, StreamCodeSynapse):
                 return synapse
+            else:
+                raise ValueError(
+                    f"Expected a StreamCodeSynapse but received {type(synapse)}"
+                )
 
         bt.logging.debug(
             f"Synapse is not StreamCodeSynapse. Miner uid {uid} completion set to '' "
@@ -83,10 +88,6 @@ async def process_response(uid: int, async_generator: Awaitable):
         )
 
         return failed_synapse
-    finally:
-        return StreamCodeSynapse(
-            completion=buffer
-        )
 
 
 async def handle_response(responses: Dict[int, Awaitable]) -> List[StreamResult]:


### PR DESCRIPTION
Hi,
This patch addresses a critical issue with the process_time. Specifically, it removes the finally block, which was unintentionally overwriting the correct internal return value, setting process_time to None.

Upon testing the validator code, I observed that the task process_time is consistently reported as 12 seconds, resulting in a speed score of 0.188875, regardless of the actual response time from miners.

The root cause of this issue is that the return statement in the finally block overwrites the return value from the try block, replacing it with None instead of the intended synapse.dendrite.process_time.

Additionally, you can verify this behavior in the W&B dashboard, where all timing metrics are recorded as 12 seconds.

Thanks & Merry Christmas :)